### PR TITLE
Added PLUGANDTRUST_I2C_PORT_NAME Kconfig option

### DIFF
--- a/lib/platform/zephyr/sm_i2c.c
+++ b/lib/platform/zephyr/sm_i2c.c
@@ -14,7 +14,6 @@
 #include "sm_port.h"
 
 /* ********************** Defines ********************** */
-#define SE05X_I2C_DEV i2c0
 #define SE05X_I2C_DEV_ADDR 0x48
 
 /* ********************** Global variables ********************** */
@@ -29,7 +28,7 @@ i2c_error_t axI2CInit(void **conn_ctx, const char *pDevName)
 {
     uint32_t i2c_cfg = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_CONTROLLER;
 
-    i2c_dev = DEVICE_DT_GET(DT_NODELABEL(SE05X_I2C_DEV));
+    i2c_dev = device_get_binding(CONFIG_PLUGANDTRUST_I2C_PORT_NAME);
     if (!i2c_dev) {
         SMLOG_E("Error in i2c device_get_binding \n");
         return I2C_FAILED;

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -16,6 +16,14 @@ config PLUGANDTRUST_SCP03
 	help
 	  This option enables secure channel for SE05x.
 
+config PLUGANDTRUST_I2C_PORT_NAME
+	string "I2C port used to connect SE05x"
+	default "I2C_0"
+	help
+	  I2C port used to connect SE05x.
+	  This is a label for the I2C port to be used,
+	  so a label in the device tree needs to be added in order for this config to work
+
 config PLUGANDTRUST_MBEDTLS_ALT
 	bool "Use ALT implementation for mbedTLS of SE05x"
 	help


### PR DESCRIPTION
Added back PLUGANDTRUST_I2C_PORT_NAME Kconfig option.
A label in the device tree needs to be used in order to make this work.