### PR TITLE
Fix overlapping memcpy in t1oi2c library

### DIFF
--- a/lib/t1oi2c/phNxpEseProto7816_3.c
+++ b/lib/t1oi2c/phNxpEseProto7816_3.c
@@ -584,7 +584,7 @@ static bool_t phNxpEseProro7816_SaveRxframeData(uint8_t *p_data, uint32_t data_l
             // LOG_W("Need '%ld' bytes. Got '%ld' to copy.", (size_t)(pRx_EseCntx->responseBytesRcvd + data_len), pRx_EseCntx->pRsp->len);
             return FALSE;
         }
-        phNxpEse_memcpy((pRx_EseCntx->pRsp->p_data + pRx_EseCntx->responseBytesRcvd), p_data, data_len);
+        memmove((pRx_EseCntx->pRsp->p_data + pRx_EseCntx->responseBytesRcvd), p_data, data_len);
         pRx_EseCntx->responseBytesRcvd += data_len;
         return TRUE;
     }


### PR DESCRIPTION
phNxpEseProro7816_SaveRxframeData() makes memcpy() calls with overlapping source/destination ranges. ASAN catches it immediately:

    ERROR: AddressSanitizer: memcpy-param-overlap: memory ranges [0xfffffffff609,0xfffffffff612) and [0xfffffffff60c, 0xfffffffff615) overlap
    #0 0xfffff789bd84 in __interceptor_memcpy /data/jenkins/workspace/GNU-toolchain/arm-12/src/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:827
    #1 0x448d7c in phNxpEse_memcpy (/root/nano_package_test+0x448d7c)
    #2 0x44a104 in phNxpEseProro7816_SaveRxframeData (/root/nano_package_test+0x44a104)
    #3 0x44a410 in phNxpEseProto7816_DecodeFrame (/root/nano_package_test+0x44a410)
    #4 0x44aea0 in phNxpEseProto7816_ProcessResponse (/root/nano_package_test+0x44aea0)
    #5 0x44b1dc in TransceiveProcess (/root/nano_package_test+0x44b1dc)
    #6 0x44b2a4 in phNxpEseProto7816_Transceive (/root/nano_package_test+0x44b2a4)
    #7 0x44852c in phNxpEse_Transceive (/root/nano_package_test+0x44852c)
    #8 0x4477f4 in smComT1oI2C_TransceiveRaw (/root/nano_package_test+0x4477f4)
    #9 0x4412a4 in Se05x_API_SessionOpen (/root/nano_package_test+0x4412a4)

Because memcpy() corrupts data when the source/destination improperly overlap, fix by replacing the offending memcpy() with memmove().